### PR TITLE
reduce coordinate precision

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"@playwright/test": "^1.28.1",
 				"@sveltejs/adapter-auto": "^2.0.0",
 				"@sveltejs/kit": "^1.27.4",
+				"@types/geojson": "^7946.0.14",
 				"@typescript-eslint/eslint-plugin": "^6.0.0",
 				"@typescript-eslint/parser": "^6.0.0",
 				"eslint": "^8.28.0",
@@ -878,9 +879,9 @@
 			"dev": true
 		},
 		"node_modules/@types/geojson": {
-			"version": "7946.0.13",
-			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.13.tgz",
-			"integrity": "sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ=="
+			"version": "7946.0.14",
+			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+			"integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"@playwright/test": "^1.28.1",
 		"@sveltejs/adapter-auto": "^2.0.0",
 		"@sveltejs/kit": "^1.27.4",
+		"@types/geojson": "^7946.0.14",
 		"@typescript-eslint/eslint-plugin": "^6.0.0",
 		"@typescript-eslint/parser": "^6.0.0",
 		"eslint": "^8.28.0",


### PR DESCRIPTION
use 6 decimal places for coordinates (a precision of ~10cm) to reduce the size of the data sent to the client from 2MB to 1.3MB.