### PR TITLE
Add row level security and policies

### DIFF
--- a/supabase/migrations/20240527220341_enable row level security.sql
+++ b/supabase/migrations/20240527220341_enable row level security.sql
@@ -1,0 +1,20 @@
+-- enable RLS on all tables
+alter table public.moments enable row level security;
+alter table public.votes enable row level security;
+alter table public.moderators enable row level security;
+
+-- create policy to allow public fetching of moments
+create policy "Moments are viewable by everyone"
+on moments for select
+to authenticated, anon
+using ( true );
+
+-- create policy to allow public inserting of moments
+create policy "Everyone can add new moments"
+on moments for insert
+to authenticated, anon
+with check ( (select auth.role()) = 'anon' ); 
+
+-- No policies for votes and moderators as those tables are not used in 1.0.
+-- Once we implement the moderating service we can write the appropriate policies.
+


### PR DESCRIPTION
This PR addresses Errors on supabase's Security Advisor by adding a new migration that:

- enables RowLevelSecurity on all tables
- allows public select and insert queries to `moments` table
- blocks public acces to `votes` and `moderators` for now