### PR TITLE
change minZoom to 3

### DIFF
--- a/src/lib/Map.svelte
+++ b/src/lib/Map.svelte
@@ -89,7 +89,7 @@
       style: style,
       center: [initialState.lng, initialState.lat],
       zoom: initialState.zoom,
-      minZoom: 2,
+      minZoom: 3,
       maxZoom: 18
     });
     map.addControl(


### PR DESCRIPTION
Temporary fix until we move to PMTiles for the moments too. There is an issue with maplibre's tiling system when showing many symbols at zooms further out than 3.