### PR TITLE
Add CI workflow with caching and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  NODE_VERSION: '22'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ env.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.NODE_VERSION }}-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint code
+        run: npm run lint

--- a/src/lib/scripts/seedData.ts
+++ b/src/lib/scripts/seedData.ts
@@ -8,7 +8,6 @@ function getRandomCoordinate(min: number, max: number): number {
 }
 
 function generateRandomWord(): string {
-  // Source: https://stackoverflow.com/a/8084248
   return (Math.random() + 1).toString(36).substring(9);
 }
 
@@ -55,6 +54,7 @@ function generateAndSaveMoments(count: number, filePath: string): void {
   // Remove empty properties from each feature
   const simplifiedMoments = {
     ...moments,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     features: moments.features.map(({ properties, ...rest }) => rest)
   };
 
@@ -71,7 +71,7 @@ function generateAndSaveDescriptions(count: number, filePath: string): void {
   saveToFile(descriptions, filePath);
 }
 
-function saveToFile(data: any, filePath: string): void {
+function saveToFile<T>(data: T, filePath: string): void {
   const dir = dirname(filePath);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });


### PR DESCRIPTION
Adds a basic github action workflow for linting. Later, we can add tests (once we've written up-to-date ones!) to this workflow and maybe run the build process from here for more flexibility than our current approach through Netlify.