### PR TITLE
fix: Prevent incomplete submissions and defer captcha verification

### DIFF
--- a/src/lib/ActionButton.svelte
+++ b/src/lib/ActionButton.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
-  export let isDisabled: boolean
+  export let isDisabled: boolean;
   export let functionOnClick: () => void;
   export let functionHover: () => void;
 </script>
 
 <div class="button-wrapper">
-  <button class="button {isDisabled ? 'button-disabled' : 'button-enabled'}" on:click={functionOnClick} on:mouseenter={functionHover} disabled={isDisabled}><slot /></button>
+  <button
+    class="button {isDisabled ? 'button-disabled' : 'button-enabled'}"
+    on:click={functionOnClick}
+    on:mouseenter={functionHover}
+    disabled={isDisabled}><slot /></button
+  >
 </div>
 
 <style>

--- a/src/lib/ActionButton.svelte
+++ b/src/lib/ActionButton.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
   export let isDisabled: boolean;
   export let functionOnClick: () => void;
-  export let functionHover: () => void;
 </script>
 
 <div class="button-wrapper">
   <button
     class="button {isDisabled ? 'button-disabled' : 'button-enabled'}"
     on:click={functionOnClick}
-    on:mouseenter={functionHover}
     disabled={isDisabled}><slot /></button
   >
 </div>

--- a/src/lib/ActionButton.svelte
+++ b/src/lib/ActionButton.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+  export let isDisabled: boolean
   export let functionOnClick: () => void;
+  export let functionHover: () => void;
 </script>
 
 <div class="button-wrapper">
-  <button class="button" on:click={functionOnClick}><slot /></button>
+  <button class="button {isDisabled ? 'button-disabled' : 'button-enabled'}" on:click={functionOnClick} on:mouseenter={functionHover} disabled={isDisabled}><slot /></button>
 </div>
 
 <style>
@@ -27,8 +29,12 @@
     margin-top: 1rem;
   }
 
-  .button:hover {
+  .button-enabled:hover {
     background-color: black;
     color: var(--color-pink);
+  }
+
+  .button:disabled {
+    cursor: not-allowed;
   }
 </style>

--- a/src/lib/AddOverlay.svelte
+++ b/src/lib/AddOverlay.svelte
@@ -17,6 +17,7 @@
   let momentDescription = '';
   let captchaToken = '';
   let isAddButtonDisabled = true;
+  let requestCaptcha = false;
 
   function closeAddOverlay() {
     addOverlayVisible.update(() => false);
@@ -40,12 +41,10 @@
     );
   };
 
-  const verifyInputs = () => {
-    isAddButtonDisabled =
+  $: isAddButtonDisabled =
       !$activeMarkerCoords?.lng ||
       !$activeMarkerCoords?.lat ||
       !momentDescription;
-  };
 
   async function handleAddMoment() {
     if (!captchaToken) {
@@ -81,6 +80,7 @@
     e: CustomEvent<TurnstileEventDetail<{ token: string }>>
   ) => {
     captchaToken = e.detail.token;
+    handleAddMoment()
   };
 
   new SvelteToast({
@@ -124,7 +124,7 @@
               class="subform"
             ></textarea>
 
-            {#if !isAddButtonDisabled}
+            {#if requestCaptcha}
               <div
                 style="margin-top: 16px"
                 use:turnstile
@@ -160,8 +160,7 @@
               >.
             </div>
             <ActionButton
-              functionOnClick={handleAddMoment}
-              functionHover={verifyInputs}
+              functionOnClick={() => requestCaptcha = true}
               isDisabled={isAddButtonDisabled}>Add</ActionButton
             >
           </form>

--- a/src/lib/AddOverlay.svelte
+++ b/src/lib/AddOverlay.svelte
@@ -41,9 +41,11 @@
   };
 
   const verifyInputs = () => {
-    isAddButtonDisabled = !$activeMarkerCoords?.lng || !$activeMarkerCoords?.lat || !momentDescription
-  }
-
+    isAddButtonDisabled =
+      !$activeMarkerCoords?.lng ||
+      !$activeMarkerCoords?.lat ||
+      !momentDescription;
+  };
 
   async function handleAddMoment() {
     if (!captchaToken) {
@@ -123,12 +125,12 @@
             ></textarea>
 
             {#if !isAddButtonDisabled}
-            <div
-              style="margin-top: 16px"
-              use:turnstile
-              turnstile-sitekey={PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY}
-              on:turnstile={handleTurnstile}
-            ></div>
+              <div
+                style="margin-top: 16px"
+                use:turnstile
+                turnstile-sitekey={PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY}
+                on:turnstile={handleTurnstile}
+              ></div>
             {/if}
             <!-- <div class="recaptcha-text">
 							This site is protected by Turnstile and Cloudflare
@@ -157,7 +159,11 @@
                 rel="noopener">Privacy Policy</a
               >.
             </div>
-            <ActionButton functionOnClick={handleAddMoment} functionHover={verifyInputs} isDisabled={isAddButtonDisabled}>Add</ActionButton>
+            <ActionButton
+              functionOnClick={handleAddMoment}
+              functionHover={verifyInputs}
+              isDisabled={isAddButtonDisabled}>Add</ActionButton
+            >
           </form>
         </div>
       </section>

--- a/src/lib/AddOverlay.svelte
+++ b/src/lib/AddOverlay.svelte
@@ -16,6 +16,7 @@
 
   let momentDescription = '';
   let captchaToken = '';
+  let isAddButtonDisabled = true;
 
   function closeAddOverlay() {
     addOverlayVisible.update(() => false);
@@ -38,6 +39,11 @@
       }
     );
   };
+
+  const verifyInputs = () => {
+    isAddButtonDisabled = !$activeMarkerCoords?.lng || !$activeMarkerCoords?.lat || !momentDescription
+  }
+
 
   async function handleAddMoment() {
     if (!captchaToken) {
@@ -116,12 +122,14 @@
               class="subform"
             ></textarea>
 
+            {#if !isAddButtonDisabled}
             <div
               style="margin-top: 16px"
               use:turnstile
               turnstile-sitekey={PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY}
               on:turnstile={handleTurnstile}
             ></div>
+            {/if}
             <!-- <div class="recaptcha-text">
 							This site is protected by Turnstile and Cloudflare
 							<a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener"
@@ -149,7 +157,7 @@
                 rel="noopener">Privacy Policy</a
               >.
             </div>
-            <ActionButton functionOnClick={handleAddMoment}>Add</ActionButton>
+            <ActionButton functionOnClick={handleAddMoment} functionHover={verifyInputs} isDisabled={isAddButtonDisabled}>Add</ActionButton>
           </form>
         </div>
       </section>

--- a/src/lib/AddOverlay.svelte
+++ b/src/lib/AddOverlay.svelte
@@ -42,9 +42,9 @@
   };
 
   $: isAddButtonDisabled =
-      !$activeMarkerCoords?.lng ||
-      !$activeMarkerCoords?.lat ||
-      !momentDescription;
+    !$activeMarkerCoords?.lng ||
+    !$activeMarkerCoords?.lat ||
+    !momentDescription;
 
   async function handleAddMoment() {
     if (!captchaToken) {
@@ -80,7 +80,7 @@
     e: CustomEvent<TurnstileEventDetail<{ token: string }>>
   ) => {
     captchaToken = e.detail.token;
-    handleAddMoment()
+    handleAddMoment();
   };
 
   new SvelteToast({
@@ -160,7 +160,7 @@
               >.
             </div>
             <ActionButton
-              functionOnClick={() => requestCaptcha = true}
+              functionOnClick={() => (requestCaptcha = true)}
               isDisabled={isAddButtonDisabled}>Add</ActionButton
             >
           </form>

--- a/src/routes/moments/+server.ts
+++ b/src/routes/moments/+server.ts
@@ -10,6 +10,10 @@ export const POST: RequestHandler = async ({ request }) => {
     return json({ error: 'CAPTCHA token is missing.' }, { status: 400 });
   }
 
+  if (!description?.trim()) {
+		return json({ error: "Description cannot be empty." }, { status: 400 });
+	}
+
   const captchaVerifyUrl =
     'https://challenges.cloudflare.com/turnstile/v0/siteverify';
   const captchaSecret = CLOUDFLARE_TURNSTILE_SECRET;

--- a/src/routes/moments/+server.ts
+++ b/src/routes/moments/+server.ts
@@ -11,8 +11,8 @@ export const POST: RequestHandler = async ({ request }) => {
   }
 
   if (!description?.trim()) {
-		return json({ error: "Description cannot be empty." }, { status: 400 });
-	}
+    return json({ error: 'Description cannot be empty.' }, { status: 400 });
+  }
 
   const captchaVerifyUrl =
     'https://challenges.cloudflare.com/turnstile/v0/siteverify';


### PR DESCRIPTION
**Related Issues**
Fixes #91 and adds input verification before allowing for moment submission 
<!-- Include a reference to any related issues. For example, "Closes #123" or "Fixes #123". -->

**Proposed Changes (Optional)**
- **reactively** disable the "Add" button if the required payload is incomplete
- defer the captcha verification until the required inputs are fulfilled and the user clicks "Add moment"

<!-- Describe the changes proposed in this pull request. Include context and any relevant details about why these changes were made. -->

**Additional context (Optional)**

<!-- Add any other context or information about the pull request here. -->
