### PR TITLE
Reduced pin size by 10%

### DIFF
--- a/src/lib/Map.svelte
+++ b/src/lib/Map.svelte
@@ -74,7 +74,7 @@
       layout: {
         'icon-allow-overlap': true,
         'icon-image': iconImage,
-        'icon-size': 0.5,
+        'icon-size': 0.45,
         'icon-anchor': 'bottom'
       },
       paint: paint


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: Reduce pin size by 10% #79 
labels: enhancement, design
assignees: Elie Simard

---

Related Issues:
Closes #79

**Proposed Changes:**

This pull request reduces the size of the pin markers on the map by 10%. The 'icon-size' property in the addPinLayer function, previously set to 0.5 (50% of the original image size), has been changed to 0.45.

**Additional Context:**

The adjustment improves visual clarity by reducing marker size, allowing more space for other map elements and potentially improving performance.

**Calculation:**

 Markers are now displayed at 45% of their original size, which is a 10% reduction from the previous size (0.5 × 0.9 = 0.45).