### PR TITLE
Popup styling uniformisation

### DIFF
--- a/src/lib/AddOverlay.svelte
+++ b/src/lib/AddOverlay.svelte
@@ -13,6 +13,7 @@
   } from '@svelte-put/cloudflare-turnstile';
   import { PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY } from '$env/static/public';
   import { SvelteToast, toast } from '@zerodevx/svelte-toast';
+  import './toast.css'; 
 
   let momentDescription = '';
   let captchaToken = '';
@@ -31,7 +32,9 @@
       'Your story was successfully submitted. It will appear publicly on the map once it has been approved by our moderators.',
       {
         theme: {
-          '--toastBarHeight': 0
+          '--toastBackground': 'black',
+          '--toastBarHeight': 0,
+          '--toastColor': 'var(--color-pink)',
         },
 
         duration: 5000
@@ -66,6 +69,7 @@
     } else {
       const result = await response.json();
       alert(`Error: ${result.error}`);
+      showSubmissionSuccessNotification();
     }
   }
 

--- a/src/lib/DonatePopup.svelte
+++ b/src/lib/DonatePopup.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { writable } from 'svelte/store';
+  import './toast.css'; 
 
   const showToast = writable(true);
 
@@ -25,61 +26,3 @@
     </div>
   </div>
 {/if}
-
-<style>
-  .toast-container {
-    position: fixed;
-    bottom: 0px;
-    left: 9px;
-    right: 70px;
-    margin: 0;
-    padding: 0;
-    list-style-type: none;
-    pointer-events: none;
-    z-index: 9999;
-  }
-  .toast {
-    width: fit-content;
-    min-height: 3.5rem;
-    margin-bottom: 0.5rem;
-    padding: 0;
-    background: black;
-    color: #fff;
-    box-shadow:
-      0 4px 6px -1px rgba(0, 0, 0, 0.1),
-      0 2px 4px -1px rgba(0, 0, 0, 0.06);
-    border: 1px solid var(--color-pink);
-    border-radius: 0.125rem;
-    display: flex;
-    align-items: center;
-    overflow: hidden;
-    pointer-events: all;
-    cursor: pointer;
-    z-index: 999;
-    position: relative;
-  }
-  .toast-message {
-    padding: 0.75rem 3rem 0.75rem 0.5rem;
-    flex: 1;
-  }
-  .toast-message a {
-    color: var(--color-pink);
-    text-decoration: unset;
-  }
-  .toast-message a span {
-    text-decoration: underline;
-  }
-  .toast-close {
-    position: absolute;
-    top: 4px;
-    right: 4px;
-    background: none;
-    border: none;
-    color: var(--color-pink);
-    cursor: pointer;
-    font: 1rem sans-serif;
-  }
-  .toast-close::after {
-    content: '✕';
-  }
-</style>

--- a/src/lib/toast.css
+++ b/src/lib/toast.css
@@ -1,0 +1,62 @@
+.toast-container {
+    position: fixed;
+    bottom: 0px;
+    left: 9px;
+    right: 70px;
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+    pointer-events: none;
+    z-index: 9999;
+  }
+  
+  .toast {
+    width: fit-content;
+    min-height: 3.5rem;
+    margin-bottom: 0.5rem;
+    padding: 0;
+    background: black;
+    color: var(--color-pink);
+    box-shadow:
+      0 4px 6px -1px rgba(0, 0, 0, 0.1),
+      0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    border: 1px solid var(--color-pink);
+    border-radius: 0.125rem;
+    display: flex;
+    align-items: center;
+    overflow: hidden;
+    pointer-events: all;
+    cursor: pointer;
+    z-index: 999;
+    position: relative;
+  }
+  
+  .toast-message {
+    padding: 0.75rem 3rem 0.75rem 0.5rem;
+    flex: 1;
+  }
+  
+  .toast-message a {
+    color: var(--color-pink);
+    text-decoration: unset;
+  }
+  
+  .toast-message a span {
+    text-decoration: underline;
+  }
+  
+  .toast-close {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    background: none;
+    border: none;
+    color: var(--color-pink);
+    cursor: pointer;
+    font: 1rem sans-serif;
+  }
+  
+  .toast-close::after {
+    content: '✕';
+  }
+  


### PR DESCRIPTION
## Uniformize Toast Styling Across Popups

**Related Issues** 

add styling to Successful submission notification to make it consistent with Donate Popup styling #78 

**Proposed Changes:**

This pull request moves the toast notification styling into a dedicated toast.css file. The styles are now shared between the DonatePopup.svelte and AddOverlay.svelte components, ensuring consistent styling for toast notifications across the application.

*** I could also simply copy the styling from DonatePopup.svelte and paste into AddOverlay.svelte if preferred approach**

**The changes include:**

Creation of toast.css to hold the toast notification styles.
Removal of inline toast styles from DonatePopup.svelte.
Importing toast.css into both DonatePopup.svelte and AddOverlay.svelte.

**Additional Context**

These changes aim to improve the maintainability and consistency of the codebase by centralizing the toast styles. This update should make it easier for future contributors to apply and manage styling for toast notifications.

<img width="309" alt="Screenshot 2024-08-21 at 3 52 37 PM" src="https://github.com/user-attachments/assets/89e4d48f-3267-4969-9ce3-33b5a4ca9a8e">
