### PR TITLE
Feat: add pre commit hook for better DX

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run format && npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint": "8.57",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-svelte": "^2.43.0",
+        "husky": "^9.1.5",
         "prettier": "^3.3.3",
         "prettier-plugin-svelte": "^3.2.6",
         "supabase": "^1.183.5",
@@ -3040,6 +3041,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.5.tgz",
+      "integrity": "sha512-rowAVRUBfI0b4+niA4SJMhfQwc107VLkBUgEYYAOQAbqDCnra1nYh83hF/MDmhYs9t9n1E3DuKOrs2LYNC+0Ag==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ieee754": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:integration": "playwright test",
     "test:unit": "vitest",
     "fetch-data": "npx vite-node --options.transformMode.ssr='/.*/' src/lib/scripts/fetchData.ts",
-    "seed-data": "npx vite-node --options.transformMode.ssr='/.*/' src/lib/scripts/seedData.ts"
+    "seed-data": "npx vite-node --options.transformMode.ssr='/.*/' src/lib/scripts/seedData.ts",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@playwright/test": "^1.45.2",
@@ -29,6 +30,7 @@
     "eslint": "8.57",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-svelte": "^2.43.0",
+    "husky": "^9.1.5",
     "prettier": "^3.3.3",
     "prettier-plugin-svelte": "^3.2.6",
     "supabase": "^1.183.5",

--- a/src/routes/moments/+server.ts
+++ b/src/routes/moments/+server.ts
@@ -1,47 +1,47 @@
-import { json } from '@sveltejs/kit';
-import type { RequestHandler } from './$types';
-import { supabase } from '$lib/clients/supabaseClient';
-import { CLOUDFLARE_TURNSTILE_SECRET } from '$env/static/private';
+import { json } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+import { supabase } from "$lib/clients/supabaseClient";
+import { CLOUDFLARE_TURNSTILE_SECRET } from "$env/static/private";
 
 export const POST: RequestHandler = async ({ request }) => {
-  const { lng, lat, description, captchaToken } = await request.json();
+	const { lng, lat, description, captchaToken } = await request.json();
 
-  if (!captchaToken) {
-    return json({ error: 'CAPTCHA token is missing.' }, { status: 400 });
-  }
+	if (!captchaToken) {
+		return json({ error: "CAPTCHA token is missing." }, { status: 400 });
+	}
 
-  const captchaVerifyUrl =
-    'https://challenges.cloudflare.com/turnstile/v0/siteverify';
-  const captchaSecret = CLOUDFLARE_TURNSTILE_SECRET;
+	const captchaVerifyUrl =
+		"https://challenges.cloudflare.com/turnstile/v0/siteverify";
+	const captchaSecret = CLOUDFLARE_TURNSTILE_SECRET;
 
-  const verifyResponse = await fetch(captchaVerifyUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      secret: captchaSecret,
-      response: captchaToken
-    })
-  });
+	const verifyResponse = await fetch(captchaVerifyUrl, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			secret: captchaSecret,
+			response: captchaToken,
+		}),
+	});
 
-  const captchaResult = await verifyResponse.json();
+	const captchaResult = await verifyResponse.json();
 
-  if (!captchaResult.success) {
-    return json({ error: 'CAPTCHA verification failed.' }, { status: 400 });
-  }
+	if (!captchaResult.success) {
+		return json({ error: "CAPTCHA verification failed." }, { status: 400 });
+	}
 
-  const { error } = await supabase.from('moments').insert([
-    {
-      description,
-      location: `SRID=4326;POINT(${lng} ${lat})`,
-      status: 'pending'
-    }
-  ]);
+	const { error } = await supabase.from("moments").insert([
+		{
+			description,
+			location: `SRID=4326;POINT(${lng} ${lat})`,
+			status: "pending",
+		},
+	]);
 
-  if (error) {
-    return json({ error: 'Error saving new moment' }, { status: 500 });
-  }
+	if (error) {
+		return json({ error: "Error saving new moment" }, { status: 500 });
+	}
 
-  return json({}, { status: 201 });
+	return json({}, { status: 201 });
 };

--- a/src/routes/moments/+server.ts
+++ b/src/routes/moments/+server.ts
@@ -1,47 +1,47 @@
-import { json } from "@sveltejs/kit";
-import type { RequestHandler } from "./$types";
-import { supabase } from "$lib/clients/supabaseClient";
-import { CLOUDFLARE_TURNSTILE_SECRET } from "$env/static/private";
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { supabase } from '$lib/clients/supabaseClient';
+import { CLOUDFLARE_TURNSTILE_SECRET } from '$env/static/private';
 
 export const POST: RequestHandler = async ({ request }) => {
-	const { lng, lat, description, captchaToken } = await request.json();
+  const { lng, lat, description, captchaToken } = await request.json();
 
-	if (!captchaToken) {
-		return json({ error: "CAPTCHA token is missing." }, { status: 400 });
-	}
+  if (!captchaToken) {
+    return json({ error: 'CAPTCHA token is missing.' }, { status: 400 });
+  }
 
-	const captchaVerifyUrl =
-		"https://challenges.cloudflare.com/turnstile/v0/siteverify";
-	const captchaSecret = CLOUDFLARE_TURNSTILE_SECRET;
+  const captchaVerifyUrl =
+    'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+  const captchaSecret = CLOUDFLARE_TURNSTILE_SECRET;
 
-	const verifyResponse = await fetch(captchaVerifyUrl, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({
-			secret: captchaSecret,
-			response: captchaToken,
-		}),
-	});
+  const verifyResponse = await fetch(captchaVerifyUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      secret: captchaSecret,
+      response: captchaToken
+    })
+  });
 
-	const captchaResult = await verifyResponse.json();
+  const captchaResult = await verifyResponse.json();
 
-	if (!captchaResult.success) {
-		return json({ error: "CAPTCHA verification failed." }, { status: 400 });
-	}
+  if (!captchaResult.success) {
+    return json({ error: 'CAPTCHA verification failed.' }, { status: 400 });
+  }
 
-	const { error } = await supabase.from("moments").insert([
-		{
-			description,
-			location: `SRID=4326;POINT(${lng} ${lat})`,
-			status: "pending",
-		},
-	]);
+  const { error } = await supabase.from('moments').insert([
+    {
+      description,
+      location: `SRID=4326;POINT(${lng} ${lat})`,
+      status: 'pending'
+    }
+  ]);
 
-	if (error) {
-		return json({ error: "Error saving new moment" }, { status: 500 });
-	}
+  if (error) {
+    return json({ error: 'Error saving new moment' }, { status: 500 });
+  }
 
-	return json({}, { status: 201 });
+  return json({}, { status: 201 });
 };


### PR DESCRIPTION
---
name: Pull Request
about: Proposing to run prettier and linter scripts at pre-commit to avoid an extra iteration if it fails in the github actions
title: (Optional) Add pre-commit hook to run npm scripts
labels: dev Xp
assignees: Narcode
---

**Related Issues**

No related issues

**Proposed Changes (Optional)**

I propose this because every time i was contributing a PR it would fail with the prettier given my IDE tools & settings. With this pre-commit the developer can make sure that at least the linter will not fail if it reaches to commit to github. 

**Additional context (Optional)**

This pre-commit is very minimalistic now but can be extended to include testing.
