### PR TITLE
Add geolocate control

### DIFF
--- a/src/lib/Map.svelte
+++ b/src/lib/Map.svelte
@@ -8,7 +8,7 @@
     type MapMouseEvent,
     type MapGeoJSONFeature
   } from 'maplibre-gl';
-  const { Map, NavigationControl, Popup } = maplibregl;
+  const { Map, NavigationControl, Popup, GeolocateControl } = maplibregl;
   import 'maplibre-gl/dist/maplibre-gl.css';
   import markerImage from '$lib/assets/marker.png';
   import markerHoveredImage from '$lib/assets/marker-hovered.png';
@@ -92,6 +92,14 @@
     });
     map.addControl(
       new NavigationControl({ showCompass: false }),
+      'bottom-right'
+    );
+    map.addControl(
+      new GeolocateControl({
+        positionOptions: {
+          enableHighAccuracy: true
+        }
+      }),
       'bottom-right'
     );
     map.keyboard.enable();


### PR DESCRIPTION
**Related Issues**

Closes #98 

**Proposed Changes (Optional)**

- users can find themselves on the map with a click
- only requests location if they click, so still totally private and in the user's control
- even if they do grant permission, the location is only shared on the client side.

**Additional context (Optional)**

I haven't discussed this change with anyone yet. Would be great if you can share any thoughts at #98.
